### PR TITLE
Command line option for logsdir

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -54,7 +54,10 @@ Things to note:
 The logs directory layout
 ---------------------------------------
 
-Directory with logfiles is named "logs" and located under test session's `basetemp`_ directory::
+Directory with logfiles is located
+    - under test session's `basetemp`_ directory named "logs"
+
+::
 
     tmp/
     └── pytest-of-aurzenligl
@@ -67,6 +70,15 @@ Directory with logfiles is named "logs" and located under test session's `basete
         └── pytest-2
             └── logs
                 (...)
+
+or
+     - under predefined location, if `--logger-logsdir` option or `logger_logsdir` entry in configuration file defined
+
+::
+
+      <logger_logsdir>/
+      └── (...)
+
 
 It has structure following pytest test item's `nodeid`_.
 
@@ -145,3 +157,13 @@ API reference
 .. _`nodeid`: http://docs.pytest.org/en/latest/writing_plugins.html#_pytest.main.Node.nodeid
 .. _`tmpdir`: http://docs.pytest.org/en/latest/tmpdir.html#the-tmpdir-fixture
 .. _`py.path.local`: http://py.rtfd.org/en/latest/path.html
+
+Command line options
+---------------------------------------
+
+`--logger-logsdir=<logsdir>`: where <logsdir> is root directory where log files are created 
+
+Configuration file parameters
+---------------------------------------
+
+`logger_logsdir=<logsdir>`: where <logsdir> is root directory where log files are created 

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -194,8 +194,12 @@ def _make_logsdir_tmpdir(tmpdirhandler):
     return logsdir
 
 
-def _make_logsdir_dir(dstname):
-    logsdir = py.path.local(dstname).ensure(dir=1)
+def _make_logsdir_dir(dstname, cleandir=True):
+    logsdir = py.path.local(dstname)
+    if cleandir:
+        if logsdir.check():
+            logsdir.remove()
+        logsdir.mkdir()
     return logsdir
 
 

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -15,15 +15,14 @@ else:
     string_type = str
 
 
-@pytest.hookimpl
 def pytest_addoption(parser):
     """Add options to control logger"""
     parser.addini(
-        name='logger_logdir',
+        name='logger_logsdir',
         help='base directory with log files for file loggers [basetemp]',
         default=None,
     )
-    parser.getgroup('logger').addoption('--logger-logdir', dest='logger_logdir')
+    parser.getgroup('logger').addoption('--logger-logsdir', dest='logger_logsdir')
 
 def pytest_configure(config):
     config.pluginmanager.register(LoggerPlugin(config), '_logger')
@@ -43,13 +42,13 @@ class LoggerPlugin(object):
         ldir = self._logsdir
         if ldir:
             return ldir
-        logger_logdir = self.config.getoption('logger_logdir')
-        if logger_logdir is None or logger_logdir == '':
-            logger_logdir = self.config.getini('logger_logdir')
-        if logger_logdir is None or logger_logdir == '':
-            ldir = _make_logsdir_tmpdir(self.config._tmpdirhandler)
+        logger_logsdir = self.config.getoption('logger_logsdir')
+        if logger_logsdir is None or logger_logsdir == '':
+            logger_logsdir = self.config.getini('logger_logsdir')
+        if logger_logsdir:
+            ldir = _make_logsdir_dir(logger_logsdir)
         else:
-            ldir = _make_logsdir_dir(logger_logdir)
+            ldir = _make_logsdir_tmpdir(self.config._tmpdirhandler)
 
         self._logsdir = ldir
 

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -24,6 +24,7 @@ def pytest_addoption(parser):
     )
     parser.getgroup('logger').addoption('--logger-logsdir', dest='logger_logsdir')
 
+
 def pytest_configure(config):
     config.pluginmanager.register(LoggerPlugin(config), '_logger')
 

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -44,7 +44,7 @@ class LoggerPlugin(object):
         if ldir:
             return ldir
         logger_logsdir = self.config.getoption('logger_logsdir')
-        if logger_logsdir is None or logger_logsdir == '':
+        if not logger_logsdir:
             logger_logsdir = self.config.getini('logger_logsdir')
         if logger_logsdir:
             ldir = _make_logsdir_dir(logger_logsdir)

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -47,13 +47,15 @@ class LoggerPlugin(object):
         if logger_logdir is None or logger_logdir == '':
             logger_logdir = self.config.getini('logger_logdir')
         if logger_logdir is None or logger_logdir == '':
-            logsdir = self.config._tmpdirhandler.getbasetemp()
-            if logsdir.basename.startswith('popen-gw'):
-                logsdir = logsdir.join('..')
+            ldir = _make_logsdir_tmpdir(self.config._tmpdirhandler)
         else:
-            logsdir = py.path.local(logger_logdir)
+            ldir = _make_logsdir_dir(logger_logdir)
 
-        ldir = self._logsdir = _make_logsdir(logsdir, self.logdirlinks)
+        self._logsdir = ldir
+
+        for link in self.logdirlinks:
+            _refresh_link(str(ldir), link)
+
         return ldir
 
     def pytest_runtest_setup(self, item):
@@ -185,10 +187,16 @@ def _refresh_link(source, link_name):
         pass
 
 
-def _make_logsdir(logsdir, logdirlinks):
+def _make_logsdir_tmpdir(tmpdirhandler):
+    logsdir = tmpdirhandler.getbasetemp()
+    if logsdir.basename.startswith('popen-gw'):
+        logsdir = logsdir.join('..')
     logsdir = logsdir.join('logs').ensure(dir=1)
-    for link in logdirlinks:
-        _refresh_link(str(logsdir), link)
+    return logsdir
+
+
+def _make_logsdir_dir(dstname):
+    logsdir = py.path.local(dstname).ensure(dir=1)
     return logsdir
 
 

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -19,8 +19,10 @@ def ls(dir, filepath=''):
 def basetemp(testdir):
     return testdir.tmpdir.join('..', 'basetemp')
 
+
 def outdir(testdir, dst):
     return testdir.tmpdir.join('..', dst)
+
 
 class FileLineMatcher(LineMatcher):
     def __init__(self, dir, filepath):
@@ -451,8 +453,7 @@ def test_logsdir_ini(testdir):
     logsdirname = 'myinilogs'
     makefile(testdir, ['pytest.ini'], """
         [pytest]
-        
-        logger_logsdir={}}
+        logger_logsdir={}
     """.format(outdir(testdir, logsdirname)))
 
     result = testdir.runpytest('-s')

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -408,7 +408,7 @@ def test_xdist(testdir):
 def test_logsdir_option(testdir, conftest_py, test_case_py):
 
     logsdir = outdir(testdir, 'myinilogs')
-    result = testdir.runpytest(['-s', '--logger-logsdir={}'.format(str(logsdir))])
+    result = testdir.runpytest('-s', '--logger-logsdir={}'.format(str(logsdir)))
     assert result.ret == 0
     result.stdout.fnmatch_lines([
         '',

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -411,7 +411,7 @@ def test_logsdir_option(testdir):
     """)
 
     logsdirname = 'myoptlogs'
-    result = testdir.runpytest('-s --logger-logsdir={}'.format(outdir(testdir, logsdirname)))
+    result = testdir.runpytest(['-s'], ['--logger-logsdir={}'.format(outdir(testdir, logsdirname))])
     assert result.ret == 0
     result.stdout.fnmatch_lines([
         '',

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -408,7 +408,7 @@ def test_xdist(testdir):
 def test_logsdir_option(testdir, conftest_py, test_case_py):
 
     logsdir = outdir(testdir, 'myinilogs')
-    result = testdir.runpytest(['-s', '--logger-logsdir={}'.format(logsdir)])
+    result = testdir.runpytest(['-s', '--logger-logsdir={}'.format(str(logsdir))])
     assert result.ret == 0
     result.stdout.fnmatch_lines([
         '',

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -467,9 +467,9 @@ def test_logsdir_cleanup(testdir, conftest_py, test_case_py):
         logger_logsdir={}
     """.format(logsdir))
 
-    makefile(logsdir, ['tmpfile'], 'this shall be removed')
+    logsdir.ensure('tmpfile').write('\n'.join(Source('this shall be removed')))
     outdir(logsdir, 'tmpdir')
-    makefile(outdir(logsdir, 'test_case'), ['foo'], 'this shall be removed')
+    outdir(logsdir, 'test_case').ensure('foo').write('\n'.join(Source('this shall be removed')))
 
     result = testdir.runpytest('-s')
     assert result.ret == 0

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -411,7 +411,7 @@ def test_logsdir_option(testdir):
     """)
 
     logsdirname = 'myoptlogs'
-    result = testdir.runpytest(['-s'], ['--logger-logsdir={}'.format(outdir(testdir, logsdirname))])
+    result = testdir.runpytest(['-s', '--logger-logsdir={}'.format(outdir(testdir, logsdirname))])
     assert result.ret == 0
     result.stdout.fnmatch_lines([
         '',

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -468,7 +468,7 @@ def test_logsdir_cleanup(testdir, conftest_py, test_case_py):
     """.format(logsdir))
 
     logsdir.ensure('tmpfile').write('\n'.join(Source('this shall be removed')))
-    subdir = logsdir.join('tmpdir')
+    logsdir.join('tmpdir')
 
     result = testdir.runpytest('-s')
     assert result.ret == 0

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -468,8 +468,7 @@ def test_logsdir_cleanup(testdir, conftest_py, test_case_py):
     """.format(logsdir))
 
     logsdir.ensure('tmpfile').write('\n'.join(Source('this shall be removed')))
-    outdir(logsdir, 'tmpdir')
-    outdir(logsdir, 'test_case').ensure('foo').write('\n'.join(Source('this shall be removed')))
+    subdir = logsdir.join('tmpdir')
 
     result = testdir.runpytest('-s')
     assert result.ret == 0


### PR DESCRIPTION
Added cmdline option `--logger-logdir=<path_to_logs>` and configuration file option `logger_logdir=<path_to_logs>`
resolves #3
