### PR TITLE
Adds support for py26

### DIFF
--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -235,7 +235,7 @@ def _make_handlers(stdoutloggers, fileloggers, item):
 def _make_stdout_handlers(loggers, fmt):
     def make_handler(logger_and_level, fmt):
         logger, level = logger_and_level
-        handler = logging.StreamHandler(stream=sys.stdout)
+        handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(fmt)
         handler.setLevel(level)
         handler.logger = logger

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -140,7 +140,7 @@ class LoggerHookspec(object):
         """
 
 
-class Formatter(logging.Formatter):
+class Formatter(logging.Formatter, object):
     short_level_names = {
         logging.FATAL: 'ftl',
         logging.ERROR: 'err',


### PR DESCRIPTION
This patch corrects two issues when attempting to use pytest-logger on py26.

* The py26 logging module uses the old-style class definition for `logging.Formatter`, which is incompatible with `super()`. See https://stackoverflow.com/a/18392639.
* The logging module changed the name of the argument for `logging.StreamHandler` from `strm` in py26, to `stream` in py27.