### PR TITLE
Custom formatter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Contributors:
 -------------
 
 Svetozar Krchnavy
+Francois Farquet

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.3.0
+-----------------------------------
+- LoggerConfig has a new set_formatter_class method to pass a logging.Formatter subclass
+
 0.2.1
 -----------------------------------
 - pytest help bug fixed: help prints properly when pytest_logger_config hook is used in test suite

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -55,6 +55,7 @@ High-level hook
 
 - command line option :ref:`--log <log option>` is added.
 - see :py:meth:`LoggerHookspec.pytest_logger_config`
+- note that :py:meth:`LoggerConfig.set_formatter_class` can be used to set a custom :py:class:`logging.Formatter` class
 
 .. _`Low-level hooks`:
 
@@ -180,7 +181,8 @@ API reference
 
 .. autoclass:: LoggerConfig()
     :members: add_loggers,
-              set_log_option_default
+              set_log_option_default,
+              set_formatter_class
 
 .. _`conftest.py`: http://docs.pytest.org/en/latest/writing_plugins.html#conftest-py
 .. _`unwanted message`: https://docs.python.org/2/howto/logging.html#what-happens-if-no-configuration-is-provided

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -185,6 +185,7 @@ class LoggerConfig(object):
         """
         if isinstance(formatter_class, logging.Formatter):
             raise ValueError("Got a formatter instance instead of its class !")
+
         if not issubclass(formatter_class, logging.Formatter):
             raise ValueError("Formatter should be a class inheriting from logging.Formatter")
         self._formatter_class = formatter_class

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -564,7 +564,7 @@ def test_logger_config_option(testdir, test_case_py, log_option):
 def test_logger_config_formatter(testdir, test_case_py, log_option):
     makefile(testdir, ['conftest.py'], """
         import logging
-    
+
         def pytest_logger_config(logger_config):
             logger_config.add_loggers(['foo', 'bar'])
             logger_config.add_loggers(['baz'], file_level='error')

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -560,6 +560,40 @@ def test_logger_config_option(testdir, test_case_py, log_option):
         ])
 
 
+@pytest.mark.parametrize('log_option', ('', '--log=foo.info,baz'))
+def test_logger_config_formatter(testdir, test_case_py, log_option):
+    makefile(testdir, ['conftest.py'], """
+        import logging
+    
+        def pytest_logger_config(logger_config):
+            logger_config.add_loggers(['foo', 'bar'])
+            logger_config.add_loggers(['baz'], file_level='error')
+            logger_config.set_formatter_class(logging.Formatter)
+    """)
+
+    opts = ('-s', log_option) if log_option else ('-s',)
+    result = testdir.runpytest(*opts)
+    assert result.ret == 0
+
+    if log_option:
+        result.stdout.fnmatch_lines([
+            '',
+            'test_case.py ',
+            'this is error',
+            'this is warning',
+            'this is info',
+            'this is error',
+            '.',
+            '',
+        ])
+    else:
+        result.stdout.fnmatch_lines([
+            '',
+            'test_case.py .',
+            '',
+        ])
+
+
 @pytest.mark.parametrize('with_hook', (False, True))
 def test_logger_config_option_missing_without_hook(testdir, test_case_py, with_hook):
     makefile(testdir, ['conftest.py'], """

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -59,6 +59,23 @@ def test_log_option_parser():
     assert str(e.value) == 'wrong logger, expected (a, b, c, d, e, f.g.h), got "alien.unknown"'
 
 
+def test_set_formatter_class():
+    logcfg = plugin.LoggerConfig()
+
+    logcfg.set_formatter_class(logging.Formatter)
+    logcfg.set_formatter_class(plugin.DefaultFormatter)
+
+    with pytest.raises(ValueError) as e:
+        logcfg.set_formatter_class(plugin.DefaultFormatter())
+    assert str(e.value) == 'Got a formatter instance instead of its class !'
+    with pytest.raises(ValueError) as e:
+        logcfg.set_formatter_class(plugin.LoggerState)
+    assert str(e.value) == 'Formatter should be a class inheriting from logging.Formatter'
+    with pytest.raises(TypeError) as e:
+        logcfg.set_formatter_class(10)
+    assert str(e.value) == 'issubclass() arg 1 must be a class'
+
+
 def test_loggers_from_logcfg_empty():
     logcfg = plugin.LoggerConfig()
 


### PR DESCRIPTION
This PR implements the feature requested in issue #7 .

- The method `LoggerConfig.set_formatter` has been added. It allows users to pass any `logging.Formatter` they need.
- The default formatter object has been renamed from `Formatter` to `DefaultFormatter` to avoid any confusion.

TODO : 
1. Documentation update
2. Version bump (0.2.2 ?)