### PR TITLE
Collect teardown logs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ upcoming
 - interface-breaking: rename --log to --loggers to maintain operability with newer pytests
 - drop pytest<3.2 from testing
 - add newer pythons and pytests to the testing matrix
+- fix: collect teardown logs
 
 0.3.0
 -----------------------------------

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -120,10 +120,10 @@ class LoggerState(object):
         self.root_enabler.enable()
 
     def on_teardown(self):
-        self.root_enabler.disable()
         self.put_newline()
 
     def on_makereport(self):
+        self.root_enabler.disable()
         _disable(self.handlers)
 
 


### PR DESCRIPTION
One of the consequences of #10 is lack of logs from teardown phase. This MR aims to fix this behavior by applying suggestion from the issue's description.

Closes #10 