### PR TITLE
Adapt plugin to newer pytests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,15 @@ env:
 matrix:
   include:
     - python: '2.7'
-      env: TOXENV=py27-pytest3{0,1,2,3,4,5,6,7}
+      env: TOXENV=py27-pytest3{2,3,4,5,6,7}
     - python: '3.5'
-      env: TOXENV=py35-pytest3{0,1,2,3,4,5,6,7}
+      env: TOXENV=py35-pytest3{2,3,4,5,6,7}
     - python: '3.6'
-      env: TOXENV=py36-pytest3{0,1,2,3,4,5,6,7}
+      env: TOXENV=py36-pytest3{2,3,4,5,6,7}
     - python: '3.7'
-      env: TOXENV=py37-pytest3{0,1,2,3,4,5,6,7}
+      env: TOXENV=py37-pytest3{2,3,4,5,6,7}
     - python: 'pypy-6.0'
-      env: TOXENV=pypy-pytest3{0,1,2,3,4,5,6,7}
+      env: TOXENV=pypy-pytest3{2,3,4,5,6,7}
 before_install:
   - python --version
   - uname -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,13 @@ env:
 matrix:
   include:
     - python: '2.7'
-      env: TOXENV=py27-pytest3{2,3,4,5,6,7}
+      env: TOXENV='py27-pytest3{2,3,4,5,6,7}'
     - python: '3.5'
-      env: TOXENV=py35-pytest3{2,3,4,5,6,7}
+      env: TOXENV='py35-pytest3{2,3,4,5,6,7}'
     - python: '3.6'
-      env: TOXENV=py36-pytest3{2,3,4,5,6,7}
-    - python: '3.7'
-      env: TOXENV=py37-pytest3{2,3,4,5,6,7}
-    - python: 'pypy-6.0'
-      env: TOXENV=pypy-pytest3{2,3,4,5,6,7}
+      env: TOXENV='py36-pytest3{2,3,4,5,6,7}'
+    - python: 'pypy-5.4'
+      env: TOXENV='pypy-pytest3{2,3,4,5,6,7}'
 before_install:
   - python --version
   - uname -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,21 +11,15 @@ env:
 matrix:
   include:
     - python: '2.7'
-      env: TOXENV=py27-pytest30
-    - python: '2.7'
-      env: TOXENV=py27-pytest31
+      env: TOXENV=py27-pytest3{0,1,2,3,4,5,6,7}
     - python: '3.5'
-      env: TOXENV=py35-pytest30
-    - python: '3.5'
-      env: TOXENV=py35-pytest31
+      env: TOXENV=py35-pytest3{0,1,2,3,4,5,6,7}
     - python: '3.6'
-      env: TOXENV=py36-pytest30
-    - python: '3.6'
-      env: TOXENV=py36-pytest31
-    - python: 'pypy-5.4'
-      env: TOXENV=pypy-pytest30
-    - python: 'pypy-5.4'
-      env: TOXENV=pypy-pytest31
+      env: TOXENV=py36-pytest3{0,1,2,3,4,5,6,7}
+    - python: '3.7'
+      env: TOXENV=py37-pytest3{0,1,2,3,4,5,6,7}
+    - python: 'pypy-6.0'
+      env: TOXENV=pypy-pytest3{0,1,2,3,4,5,6,7}
 before_install:
   - python --version
   - uname -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
       env: TOXENV='py35-pytest3{2,3,4,5,6,7}'
     - python: '3.6'
       env: TOXENV='py36-pytest3{2,3,4,5,6,7}'
+    - python: '3.7'
+      dist: xenial
+      sudo: true
+      env: TOXENV='py37-pytest3{2,3,4,5,6,7}'
     - python: 'pypy-5.4'
       env: TOXENV='pypy-pytest3{2,3,4,5,6,7}'
 before_install:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+upcoming
+-----------------------------------
+- interface-breaking: rename --log to --loggers to maintain operability with newer pytests
+- drop pytest<3.2 from testing
+- add newer pythons and pytests to the testing matrix
+
 0.3.0
 -----------------------------------
 - LoggerConfig has a new set_formatter_class method to pass a logging.Formatter subclass

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
     - TOXENV: 'py27-pytest3{2,3,4,5,6,7}'
     - TOXENV: 'py35-pytest3{2,3,4,5,6,7}'
     - TOXENV: 'py36-pytest3{2,3,4,5,6,7}'
+    - TOXENV: 'py37-pytest3{2,3,4,5,6,7}'
     - TOXENV: 'pypy-pytest3{2,3,4,5,6,7}'
 init:
   - ps: echo $env:TOXENV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,11 @@ cache:
 environment:
   matrix:
     - TOXENV: check
-    - TOXENV: 'py27-pytest3{0,1,2,3,4,5,6,7}'
-    - TOXENV: 'py35-pytest3{0,1,2,3,4,5,6,7}'
-    - TOXENV: 'py36-pytest3{0,1,2,3,4,5,6,7}'
-    - TOXENV: 'py37-pytest3{0,1,2,3,4,5,6,7}'
-    - TOXENV: 'pypy-pytest3{0,1,2,3,4,5,6,7}'
+    - TOXENV: 'py27-pytest3{2,3,4,5,6,7}'
+    - TOXENV: 'py35-pytest3{2,3,4,5,6,7}'
+    - TOXENV: 'py36-pytest3{2,3,4,5,6,7}'
+    - TOXENV: 'py37-pytest3{2,3,4,5,6,7}'
+    - TOXENV: 'pypy-pytest3{2,3,4,5,6,7}'
 init:
   - ps: echo $env:TOXENV
   - ps: ls C:\Python*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,11 @@ cache:
 environment:
   matrix:
     - TOXENV: check
-    - TOXENV: 'py27-pytest30,py27-pytest31'
-    - TOXENV: 'py35-pytest30,py35-pytest31'
-    - TOXENV: 'py36-pytest30,py36-pytest31'
-    - TOXENV: 'pypy-pytest30,pypy-pytest31'
+    - TOXENV: 'py27-pytest3{0,1,2,3,4,5,6,7}'
+    - TOXENV: 'py35-pytest3{0,1,2,3,4,5,6,7}'
+    - TOXENV: 'py36-pytest3{0,1,2,3,4,5,6,7}'
+    - TOXENV: 'py37-pytest3{0,1,2,3,4,5,6,7}'
+    - TOXENV: 'pypy-pytest3{0,1,2,3,4,5,6,7}'
 init:
   - ps: echo $env:TOXENV
   - ps: ls C:\Python*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ environment:
     - TOXENV: 'py27-pytest3{2,3,4,5,6,7}'
     - TOXENV: 'py35-pytest3{2,3,4,5,6,7}'
     - TOXENV: 'py36-pytest3{2,3,4,5,6,7}'
-    - TOXENV: 'py37-pytest3{2,3,4,5,6,7}'
     - TOXENV: 'pypy-pytest3{2,3,4,5,6,7}'
 init:
   - ps: echo $env:TOXENV

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -47,13 +47,13 @@ High-level hook
     def pytest_logger_config(logger_config):
         # adds two loggers, which will:
         #   - log to filesystem at all levels
-        #   - log to terminal with default WARN level if provided in --log option
+        #   - log to terminal with default WARN level if provided in --loggers option
         logger_config.add_loggers(['foo', 'bar'], stdout_level='warn')
 
-        # default --log option is set to log foo at WARN level and bar at NOTSET
+        # default --loggers option is set to log foo at WARN level and bar at NOTSET
         logger_config.set_log_option_default('foo,bar.notset')
 
-- command line option :ref:`--log <log option>` is added.
+- command line option :ref:`--loggers <loggers option>` is added.
 - see :py:meth:`LoggerHookspec.pytest_logger_config`
 - note that :py:meth:`LoggerConfig.set_formatter_class` can be used to set a custom :py:class:`logging.Formatter` class
 
@@ -199,9 +199,9 @@ Command line options
 `--logger-logsdir=<logsdir>`
     where <logsdir> is root directory where log files are created
 
-.. _`log option`:
+.. _`loggers option`:
 
-`--log=<loggers>`
+`--loggers=<loggers>`
     where <loggers> are a comma delimited list of loggers optionally suffixed
     with level preceded by a dot. Levels can be lower or uppercase, or numeric.
     For example: "logger1,logger2.info,logger3.FATAL,logger4.25"

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -29,7 +29,7 @@ def _late_addoptions(parser, logcfg):
 
     if logcfg._enabled:
         parser = _log_option_parser(logcfg._loggers)
-        group.addoption('--log',
+        group.addoption('--loggers',
                         default=parser(logcfg._log_option_default),
                         type=parser,
                         metavar='LOGGER,LOGGER.LEVEL,...',
@@ -60,7 +60,7 @@ class LoggerPlugin(object):
     def __init__(self, config, logcfg):
         self._config = config
         self._logdirlinks = config.hook.pytest_logger_logdirlink(config=config)
-        self._loggers = _loggers_from_logcfg(logcfg, config.getoption('log')) if logcfg._enabled else None
+        self._loggers = _loggers_from_logcfg(logcfg, config.getoption('loggers')) if logcfg._enabled else None
         self._formatter_class = logcfg._formatter_class or DefaultFormatter
         self._logsdir = None
 
@@ -163,7 +163,7 @@ class LoggerConfig(object):
     def add_loggers(self, loggers, stdout_level=logging.NOTSET, file_level=logging.NOTSET):
         """Adds loggers for stdout/filesystem handling.
 
-        Stdout: loggers will log to stdout only when mentioned in `log` option. If they're
+        Stdout: loggers will log to stdout only when mentioned in `loggers` option. If they're
         mentioned without explicit level, `stdout_level` will be used.
 
         Filesystem: loggers will log to files at `file_level`.

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -661,3 +661,12 @@ def test_help_prints(testdir, test_case_py):
 
     result = testdir.runpytest('-s', '--help')
     assert result.ret == 0
+
+
+@pytest.mark.skip("Since pytest v3.3 progress percentage is being displayed by default during test execution. "
+                  "It interferes with most of the old test cases that assert stdout/err so to not change them, we are "
+                  "now forcing classic output with a force_classic_output auto-use fixture which overrides pytest's "
+                  "console_output_style. We could have at least one test that proves the plugin can work in the new"
+                  "default mode as well.")
+def test_works_with_progress_percentage_prints():
+    assert False

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -25,7 +25,7 @@ def outdir(testdir, dst):
 
 
 @pytest.fixture(autouse=True)
-def force_classic_output(monkeypatch, testdir):
+def set_classic_output(monkeypatch, testdir):
     runpytest = testdir.runpytest
 
     def wrapper(*args, **kwargs):
@@ -665,7 +665,7 @@ def test_help_prints(testdir, test_case_py):
 
 @pytest.mark.skip("Since pytest v3.3 progress percentage is being displayed by default during test execution. "
                   "It interferes with most of the old test cases that assert stdout/err so to not change them, we are "
-                  "now forcing classic output with a force_classic_output auto-use fixture which overrides pytest's "
+                  "now forcing classic output with a set_classic_output auto-use fixture which overrides pytest's "
                   "console_output_style. We could have at least one test that proves the plugin can work in the new"
                   "default mode as well.")
 def test_works_with_progress_percentage_prints():

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     pdbpp
     rpdb
 commands =
-    py.test {posargs} --tb=short -x --strict tests
+    py.test {posargs} -rS --tb=short -x --strict tests
 
 [testenv:check]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,12 @@
 [tox]
 envlist =
     check,
-    py{27,35,36,37,py}-pytest3{0,1,2,3,4,5,6,7},
+    py{27,35,36,37,py}-pytest3{2,3,4,5,6,7},
     docs
 
 [testenv]
 usedevelop = True
 deps =
-    pytest30: pytest==3.0.*
-    pytest31: pytest==3.1.*
     pytest32: pytest==3.2.*
     pytest33: pytest==3.3.*
     pytest34: pytest==3.4.*
@@ -39,7 +37,7 @@ changedir=.
 whitelist_externals =
     sh
 deps =
-    pytest
+    pytest==3.7.*
     pytest-xdist
     coverage
     coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     check,
-    {py27,py35,py36,pypy}-pytest{30,31},
+    py{27,35,36,37,py}-pytest3{0,1,2,3,4,5,6,7},
     docs
 
 [testenv]
@@ -9,6 +9,12 @@ usedevelop = True
 deps =
     pytest30: pytest==3.0.*
     pytest31: pytest==3.1.*
+    pytest32: pytest==3.2.*
+    pytest33: pytest==3.3.*
+    pytest34: pytest==3.4.*
+    pytest35: pytest==3.5.*
+    pytest36: pytest==3.6.*
+    pytest37: pytest==3.7.*
     pytest-xdist
     pdbpp
     rpdb


### PR DESCRIPTION
In order to adapt the plugin to newer pytests (and fix #11 at the same time) I did the following:
- renamed conflicting `--log` option to `--loggers`.
- forced the console output style of pytest in tests to the classic one because of the asserts on stdout/err
- left a skipped test -- a placeholder for the new default console output of pytest
- extended testing matrix

Closes #11