### PR TITLE
easy access to logs from failed tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.5.0
+-----------------------------------
+- create a 'failedlogs' directory with symlinks to logs from failed tests inside the main logs directory
+
 0.4.0
 -----------------------------------
 - interface-breaking: rename --log to --loggers to maintain operability with newer pytests

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ next
 -----------------------------------
 - class with testcases is represented with additional directory instead of '.'
   separating class name and testcase name
-- create a 'failedlogs' directory with symlinks to logs from failed tests inside the main logs directory
+- add the "divide by result" functionality
 
 0.4.0
 -----------------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ next
 -----------------------------------
 - class with testcases is represented with additional directory instead of '.'
   separating class name and testcase name
-- add the "divide by result" functionality
+- add the "split logs by outcome" functionality
 
 0.4.0
 -----------------------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -136,17 +136,17 @@ It has structure following pytest test item's `nodeid`_.
             └── proc
 
 
-.. _`divide logs by result`:
+.. _`split logs by outcome`:
 
-Divide logs by result
+Split logs by outcome
 ---------------------------------------
-It is possible to divide the logs by test result. If chosen to do so (by calling below method):
+It is possible to split the logs by test outcome. If chosen to do so (by calling below method):
 
 ::
 
     # content of conftest.py
     def pytest_logger_config(logger_config):
-        logger_config.divide_logs_by_result()
+        logger_config.split_by_outcome()
 
 Will result in below directory structure:
 
@@ -161,7 +161,7 @@ Will result in below directory structure:
     │           |   └── setup
     |           └── test_that_failed_two
     |               └── somelogfile
-    ├── div_by_res
+    ├── by_outcome
     |   └── failed
     |       ├── classtests
     │       |   └── test_y.py
@@ -175,7 +175,7 @@ Will result in below directory structure:
         └── test_that_failed_one
             └── somelog
 
-You can change the default `div_by_res` dirname to something else, as well as add more "per-result" subdirectories by passing proper arguments to the `divide_logs_by_result` method.
+You can change the default `by_outcome` dirname to something else, as well as add more "per-outcome" subdirectories by passing proper arguments to the `split_by_outcome` method.
 
 .. _`link to logs dir`:
 
@@ -227,7 +227,7 @@ API reference
     :members: add_loggers,
               set_log_option_default,
               set_formatter_class,
-              divide_logs_by_result
+              split_by_outcome
 
 .. _`conftest.py`: http://docs.pytest.org/en/latest/writing_plugins.html#conftest-py
 .. _`unwanted message`: https://docs.python.org/2/howto/logging.html#what-happens-if-no-configuration-is-provided

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -116,7 +116,7 @@ It has structure following pytest test item's `nodeid`_.
     - test classes are directories
     - test functions are directories (each parametrized testcase variant is distinct)
     - each registered logger is a file (root logger is called 'root')
-    - if some test fails, additional directory named `failedlogsdir` is created in top-level logs directory. It wil contain the same exact directory tree as the original one, and a symbolic link at the end (pointing th the original directory with logs from that testcase)
+    - if some test fails, additional directory named `failedlogs` is created in top-level logs directory. It wil contain the same exact directory tree as the original one, and a symbolic link at the end (pointing th the original directory with logs from that testcase)
 
 ::
 
@@ -129,7 +129,7 @@ It has structure following pytest test item's `nodeid`_.
     │           |   └── setup
     |           └── test_that_failed_two
     |               └── somelogfile
-    ├── failedlogsdir
+    ├── failedlogs
     |   ├── classtests
     │   |   └── test_y.py
     │   |       └── TestClass

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -116,6 +116,7 @@ It has structure following pytest test item's `nodeid`_.
     - test classes are directories
     - test functions are directories (each parametrized testcase variant is distinct)
     - each registered logger is a file (root logger is called 'root')
+    - if some test fails, additional directory named `failedlogsdir` is created in top-level logs directory. It wil contain the same exact directory tree as the original one, and a symbolic link at the end (pointing th the original directory with logs from that testcase)
 
 ::
 
@@ -123,17 +124,28 @@ It has structure following pytest test item's `nodeid`_.
     ├── classtests
     │   └── test_y.py
     │       └── TestClass
-    │           └── test_class
-    │               ├── daemon
-    │               └── setup
+    │           ├── test_class
+    │           |   ├── daemon
+    │           |   └── setup
+    |           └── test_that_failed_two
+    |               └── somelogfile
+    ├── failedlogsdir
+    |   ├── classtests
+    │   |   └── test_y.py
+    │   |       └── TestClass
+    |   |           └── test_that_failed_two -> ../../../../../test_that_failed_two
+    |   └── test_p.py
+    |       └── test_that_failed_one -> ../../../test_p.py/test_that_failed_one
     ├── parametrictests
     │   └── test_z.py
     │       ├── test_param-2-abc
     │       └── test_param-4.127-de
     │           └── setup
     └── test_p.py
-        └── test_cat
-            └── proc
+        ├── test_cat
+        |   └── proc
+        └── test_that_failed_one
+            └── somelog
 
 .. _`link to logs dir`:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -226,7 +226,8 @@ API reference
 .. autoclass:: LoggerConfig()
     :members: add_loggers,
               set_log_option_default,
-              set_formatter_class
+              set_formatter_class,
+              divide_logs_by_result
 
 .. _`conftest.py`: http://docs.pytest.org/en/latest/writing_plugins.html#conftest-py
 .. _`unwanted message`: https://docs.python.org/2/howto/logging.html#what-happens-if-no-configuration-is-provided

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -116,7 +116,39 @@ It has structure following pytest test item's `nodeid`_.
     - test classes are directories
     - test functions are directories (each parametrized testcase variant is distinct)
     - each registered logger is a file (root logger is called 'root')
-    - if some test fails, additional directory named `failedlogs` is created in top-level logs directory. It wil contain the same exact directory tree as the original one, and a symbolic link at the end (pointing th the original directory with logs from that testcase)
+
+::
+
+    logs/
+    ├── classtests
+    │   └── test_y.py
+    │       └── TestClass
+    │           └── test_class
+    │               ├── daemon
+    │               └── setup
+    ├── parametrictests
+    │   └── test_z.py
+    │       ├── test_param-2-abc
+    │       └── test_param-4.127-de
+    │           └── setup
+    └── test_p.py
+        └── test_cat
+            └── proc
+
+
+.. _`divide logs by result`:
+
+Divide logs by result
+---------------------------------------
+It is possible to divide the logs by test result. If chosen to do so (by calling below method):
+
+::
+
+    # content of conftest.py
+    def pytest_logger_config(logger_config):
+        logger_config.divide_logs_by_result()
+
+Will result in below directory structure:
 
 ::
 
@@ -129,23 +161,21 @@ It has structure following pytest test item's `nodeid`_.
     │           |   └── setup
     |           └── test_that_failed_two
     |               └── somelogfile
-    ├── failedlogs
-    |   ├── classtests
-    │   |   └── test_y.py
-    │   |       └── TestClass
-    |   |           └── test_that_failed_two -> ../../../../../test_that_failed_two
-    |   └── test_p.py
-    |       └── test_that_failed_one -> ../../../test_p.py/test_that_failed_one
-    ├── parametrictests
-    │   └── test_z.py
-    │       ├── test_param-2-abc
-    │       └── test_param-4.127-de
-    │           └── setup
+    ├── div_by_res
+    |   └── failed
+    |       ├── classtests
+    │       |   └── test_y.py
+    │       |       └── TestClass
+    |       |           └── test_that_failed_two -> ../../../../../../classtests/test_y.py/TestClass/test_that_failed_two
+    |       └── test_p.py
+    |           └── test_that_failed_one -> ../../../../test_p.py/test_that_failed_one
     └── test_p.py
         ├── test_cat
         |   └── proc
         └── test_that_failed_one
             └── somelog
+
+You can change the default `div_by_res` dirname to something else, as well as add more "per-result" subdirectories by passing proper arguments to the `divide_logs_by_result` method.
 
 .. _`link to logs dir`:
 

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -110,7 +110,7 @@ class LoggerPlugin(object):
                 nodepath = os.path.dirname(nodeid)
                 failedlogsdir.join(nodepath).ensure(dir=1)
                 destdir_relpath = os.path.relpath(str(self._logsdir.join(nodeid)), str(failedlogsdir.join(nodepath)))
-                os.symlink(destdir_relpath, str(failedlogsdir.join(nodeid)))
+                _refresh_link(destdir_relpath, str(failedlogsdir.join(nodeid)))
             if call.when == 'teardown':
                 logger.on_makereport()
 

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -10,8 +10,6 @@ import argparse
 from builtins import object, int
 from past.builtins import basestring
 
-win32 = sys.platform == 'win32'
-
 
 def pytest_addhooks(pluginmanager):
     pluginmanager.add_hookspecs(LoggerHookspec)
@@ -105,14 +103,14 @@ class LoggerPlugin(object):
         tr = outcome.get_result()
         logger = getattr(item, '_logger', None)
         if logger:
-            if not win32 and sys.version_info >= (3, 6, ) and tr.outcome == 'failed' and self._logsdir:
+            if tr.outcome == 'failed' and self._logsdir:
                 failedlogsdir = self._logsdir.join('failedlogs')
                 failedlogsdir.ensure(dir=1)
                 nodeid = _sanitize_nodeid(item.nodeid)
                 nodepath = os.path.dirname(nodeid)
                 failedlogsdir.join(nodepath).ensure(dir=1)
-                destdir_relpath = os.path.relpath(self._logsdir.join(nodeid), failedlogsdir.join(nodepath))
-                os.symlink(destdir_relpath, failedlogsdir.join(nodeid), target_is_directory=True)
+                destdir_relpath = os.path.relpath(str(self._logsdir.join(nodeid)), str(failedlogsdir.join(nodepath)))
+                os.symlink(destdir_relpath, str(failedlogsdir.join(nodeid)))
             if call.when == 'teardown':
                 logger.on_makereport()
 

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -106,13 +106,11 @@ class LoggerPlugin(object):
             if tr.outcome == 'failed':
                 failedlogsdir = self._logsdir.join('failedlogs')
                 failedlogsdir.ensure(dir=1)
-
                 nodeid = _sanitize_nodeid(item.nodeid)
-                nodepath, nodename = os.path.split(nodeid)
+                nodepath = os.path.dirname(nodeid)
                 failedlogsdir.join(nodepath).ensure(dir=1)
-                # depth = nodeid.count(os.pathsep)
-                #os.symlink(os.path.join(*([os.pardir]*depth), nodeid), failedlogsdir.join(nodeid), target_is_directory=True)
-                os.symlink(self._logsdir.join(nodeid), failedlogsdir.join(nodeid), target_is_directory=True)
+                destdir_relpath=os.path.relpath(self._logsdir.join(nodeid), failedlogsdir.join(nodepath))
+                os.symlink(destdir_relpath, failedlogsdir.join(nodeid), target_is_directory=True)
             if call.when == 'teardown':
                 logger.on_makereport()
 

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -216,7 +216,6 @@ class LoggerConfig(object):
 
         :param div_by_res_logdir: name for the subdirectory in main log directory
         :param div_by_res_subdirs: list of test results to be handled (failed/passed)
-        :return:
         """
         self._div_by_res_logdir = div_by_res_logdir
         self._div_by_res_subdirs = div_by_res_subdirs

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -220,7 +220,7 @@ class LoggerConfig(object):
             allowed_outcomes = ['passed', 'failed', 'skipped']
             unexpected_outcomes = set(outcomes) - set(allowed_outcomes)
             if unexpected_outcomes:
-                raise ValueError('got unexpected_outcomes: <' + str(unexpected_outcomes) + '>')
+                raise ValueError('got unexpected_outcomes: <' + str(list(unexpected_outcomes)) + '>')
             self._split_by_outcome_outcomes = outcomes
         else:
             self._split_by_outcome_outcomes = ['failed']

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -103,7 +103,7 @@ class LoggerPlugin(object):
         tr = outcome.get_result()
         logger = getattr(item, '_logger', None)
         if logger:
-            if tr.outcome == 'failed':
+            if tr.outcome == 'failed' and self._logsdir:
                 failedlogsdir = self._logsdir.join('failedlogs')
                 failedlogsdir.ensure(dir=1)
                 nodeid = _sanitize_nodeid(item.nodeid)

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -103,7 +103,7 @@ class LoggerPlugin(object):
         tr = outcome.get_result()
         logger = getattr(item, '_logger', None)
         if logger:
-            if sys.version_info.major >= 3 and tr.outcome == 'failed' and self._logsdir:
+            if sys.version_info >= (3, 6, ) and tr.outcome == 'failed' and self._logsdir:
                 failedlogsdir = self._logsdir.join('failedlogs')
                 failedlogsdir.ensure(dir=1)
                 nodeid = _sanitize_nodeid(item.nodeid)

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -103,7 +103,7 @@ class LoggerPlugin(object):
         tr = outcome.get_result()
         logger = getattr(item, '_logger', None)
         if logger:
-            if tr.outcome == 'failed' and self._logsdir:
+            if sys.version_info.major >= 3 and tr.outcome == 'failed' and self._logsdir:
                 failedlogsdir = self._logsdir.join('failedlogs')
                 failedlogsdir.ensure(dir=1)
                 nodeid = _sanitize_nodeid(item.nodeid)

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -109,7 +109,7 @@ class LoggerPlugin(object):
                 nodeid = _sanitize_nodeid(item.nodeid)
                 nodepath = os.path.dirname(nodeid)
                 failedlogsdir.join(nodepath).ensure(dir=1)
-                destdir_relpath=os.path.relpath(self._logsdir.join(nodeid), failedlogsdir.join(nodepath))
+                destdir_relpath = os.path.relpath(self._logsdir.join(nodeid), failedlogsdir.join(nodepath))
                 os.symlink(destdir_relpath, failedlogsdir.join(nodeid), target_is_directory=True)
             if call.when == 'teardown':
                 logger.on_makereport()
@@ -211,7 +211,7 @@ class LoggerHookspec(object):
     def pytest_logger_config(self, logger_config):
         """ called before cmdline options parsing. Accepts terse configuration
         of both stdout and file logging, adds cmdline options to manipulate
-        stdout logging. Cannot be used together with \*loggers hooks.
+        stdout logging. Cannot be used together with *loggers hooks.
 
         :arg logger_config: instance of :py:class:`LoggerConfig`, allows
            setting loggers for stdout and file handling and their levels.

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -10,6 +10,8 @@ import argparse
 from builtins import object, int
 from past.builtins import basestring
 
+win32 = sys.platform == 'win32'
+
 
 def pytest_addhooks(pluginmanager):
     pluginmanager.add_hookspecs(LoggerHookspec)
@@ -103,7 +105,7 @@ class LoggerPlugin(object):
         tr = outcome.get_result()
         logger = getattr(item, '_logger', None)
         if logger:
-            if sys.version_info >= (3, 6, ) and tr.outcome == 'failed' and self._logsdir:
+            if not win32 and sys.version_info >= (3, 6, ) and tr.outcome == 'failed' and self._logsdir:
                 failedlogsdir = self._logsdir.join('failedlogs')
                 failedlogsdir.ensure(dir=1)
                 nodeid = _sanitize_nodeid(item.nodeid)

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -218,7 +218,18 @@ def test_file_handlers(testdir, conftest_py, test_case_py):
 
 
 @pytest.mark.skipif(win32py2, reason="python 2 on windows doesn't have symlink feature")
-def test_failedlogsdir(testdir, conftest_py):
+def test_divide_logs_by_result(testdir):
+    makefile(testdir, ['conftest.py'], """
+        import logging
+        def pytest_logger_fileloggers(item):
+            return [
+                'foo',
+                ('bar', logging.ERROR),
+            ]
+
+        def pytest_logger_config(logger_config):
+            logger_config.divide_logs_by_result(div_by_res_subdirs=['passed', 'failed'])
+    """)
     makefile(testdir, ['test_case.py'], """
             import pytest
             import logging
@@ -227,20 +238,35 @@ def test_failedlogsdir(testdir, conftest_py):
                     lgr.error('this is error')
                     lgr.warning('this is warning')
                 pytest.fail('just checking')
+
+            def test_case_that_passes():
+                for lgr in (logging.getLogger(name) for name in ['foo', 'bar', 'baz']):
+                    lgr.error('this is error')
+                    lgr.warning('this is warning')
         """)
     result = testdir.runpytest('-s')
     assert result.ret != 0
     result.stdout.fnmatch_lines([
         '',
-        'test_case.py F',
+        'test_case.py F.',
         '',
     ])
 
-    assert 'failedlogs' in ls(basetemp(testdir).join('logs'))
-    failedlogpath = basetemp(testdir).join('logs', 'failedlogs', 'test_case.py', 'test_case_that_fails')
+    assert 'div_by_res' in ls(basetemp(testdir).join('logs'))
+
+    assert 'failed' in ls(basetemp(testdir).join('logs', 'div_by_res'))
+    failedlogpath = basetemp(testdir).join('logs', 'div_by_res', 'failed', 'test_case.py', 'test_case_that_fails')
     assert failedlogpath.islink()
-    failedlogdest = os.path.join(os.path.pardir, os.path.pardir, 'test_case.py', 'test_case_that_fails')
+    failedlogdest = os.path.join(
+        os.path.pardir, os.path.pardir, os.path.pardir, 'test_case.py', 'test_case_that_fails')
     assert os.readlink(str(failedlogpath)) == failedlogdest
+
+    assert 'passed' in ls(basetemp(testdir).join('logs', 'div_by_res'))
+    passedlogpath = basetemp(testdir).join('logs', 'div_by_res', 'passed', 'test_case.py', 'test_case_that_passes')
+    assert passedlogpath.islink()
+    passedlogdest = os.path.join(
+        os.path.pardir, os.path.pardir, os.path.pardir, 'test_case.py', 'test_case_that_passes')
+    assert os.readlink(str(passedlogpath)) == passedlogdest
 
 
 def test_file_handlers_root(testdir):

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -216,8 +216,8 @@ def test_file_handlers(testdir, conftest_py, test_case_py):
     ])
 
 
-@pytest.mark.skipif(sys.version_info.major < 3,
-                    reason="AttributeError: 'LocalPath' object has no attribute 'startswith'")
+@pytest.mark.skipif(sys.version_info < (3, 6, ),
+                    reason="Requires python 3.6+")
 def test_failedlogsdir(testdir, conftest_py):
     makefile(testdir, ['test_case.py'], """
             import pytest

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -5,8 +5,9 @@ import platform
 from py.code import Source
 from _pytest.pytester import LineMatcher
 
-win32py2 = sys.platform == 'win32' and sys.version_info[0] == 2
-win32pypy = sys.platform == 'win32' and platform.python_implementation() == 'PyPy'
+win32 = sys.platform == 'win32'
+win32py2 = win32 and sys.version_info[0] == 2
+win32pypy = win32 and platform.python_implementation() == 'PyPy'
 
 
 def makefile(testdir, path, content):
@@ -216,8 +217,8 @@ def test_file_handlers(testdir, conftest_py, test_case_py):
     ])
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6, ),
-                    reason="Requires python 3.6+")
+@pytest.mark.skipif(sys.version_info < (3, 6, ) or win32,
+                    reason="Requires linux and python 3.6+")
 def test_failedlogsdir(testdir, conftest_py):
     makefile(testdir, ['test_case.py'], """
             import pytest

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -218,7 +218,7 @@ def test_file_handlers(testdir, conftest_py, test_case_py):
 
 
 @pytest.mark.skipif(win32py2, reason="python 2 on windows doesn't have symlink feature")
-def test_divide_logs_by_result(testdir):
+def test_split_logs_by_outcome(testdir):
     makefile(testdir, ['conftest.py'], """
         import logging
         def pytest_logger_fileloggers(item):
@@ -228,7 +228,7 @@ def test_divide_logs_by_result(testdir):
             ]
 
         def pytest_logger_config(logger_config):
-            logger_config.divide_logs_by_result(div_by_res_subdirs=['passed', 'failed'])
+            logger_config.split_by_outcome(outcomes=['passed', 'failed'])
     """)
     makefile(testdir, ['test_case.py'], """
             import pytest
@@ -252,17 +252,17 @@ def test_divide_logs_by_result(testdir):
         '',
     ])
 
-    assert 'div_by_res' in ls(basetemp(testdir).join('logs'))
+    assert 'by_outcome' in ls(basetemp(testdir).join('logs'))
 
-    assert 'failed' in ls(basetemp(testdir).join('logs', 'div_by_res'))
-    failedlogpath = basetemp(testdir).join('logs', 'div_by_res', 'failed', 'test_case.py', 'test_case_that_fails')
+    assert 'failed' in ls(basetemp(testdir).join('logs', 'by_outcome'))
+    failedlogpath = basetemp(testdir).join('logs', 'by_outcome', 'failed', 'test_case.py', 'test_case_that_fails')
     assert failedlogpath.islink()
     failedlogdest = os.path.join(
         os.path.pardir, os.path.pardir, os.path.pardir, 'test_case.py', 'test_case_that_fails')
     assert os.readlink(str(failedlogpath)) == failedlogdest
 
-    assert 'passed' in ls(basetemp(testdir).join('logs', 'div_by_res'))
-    passedlogpath = basetemp(testdir).join('logs', 'div_by_res', 'passed', 'test_case.py', 'test_case_that_passes')
+    assert 'passed' in ls(basetemp(testdir).join('logs', 'by_outcome'))
+    passedlogpath = basetemp(testdir).join('logs', 'by_outcome', 'passed', 'test_case.py', 'test_case_that_passes')
     assert passedlogpath.islink()
     passedlogdest = os.path.join(
         os.path.pardir, os.path.pardir, os.path.pardir, 'test_case.py', 'test_case_that_passes')

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -217,8 +217,7 @@ def test_file_handlers(testdir, conftest_py, test_case_py):
     ])
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6, ) or win32,
-                    reason="Requires linux and python 3.6+")
+@pytest.mark.skipif(win32py2, reason="python 2 on windows doesn't have symlink feature")
 def test_failedlogsdir(testdir, conftest_py):
     makefile(testdir, ['test_case.py'], """
             import pytest
@@ -241,7 +240,7 @@ def test_failedlogsdir(testdir, conftest_py):
     failedlogpath = basetemp(testdir).join('logs', 'failedlogs', 'test_case.py', 'test_case_that_fails')
     assert failedlogpath.islink()
     failedlogdest = os.path.join(os.path.pardir, os.path.pardir, 'test_case.py', 'test_case_that_fails')
-    assert failedlogpath.readlink() == failedlogdest
+    assert os.readlink(str(failedlogpath)) == failedlogdest
 
 
 def test_file_handlers_root(testdir):

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -96,3 +96,9 @@ def test_loggers_from_logcfg():
     assert loggers.stdout == [('b', logging.FATAL), ('d', 10)]
     assert loggers.file == [('a', logging.WARN), ('b', logging.WARN), ('c', logging.WARN), ('d', 0)]
     assert loggers
+
+
+def test_split_by_outcome_wrong_config():
+    logcfg = plugin.LoggerConfig()
+    with pytest.raises(ValueError, match="got unexpected_outcomes: <\\['sthelese'\\]>"):
+        logcfg.split_by_outcome(outcomes=['failed', 'sthelese'])

--- a/tox.ini
+++ b/tox.ini
@@ -8,12 +8,17 @@ envlist =
 usedevelop = True
 deps =
     pytest32: pytest==3.2.*
+    pytest32: pytest-xdist<1.25.0
     pytest33: pytest==3.3.*
+    pytest33: pytest-xdist<1.25.0
     pytest34: pytest==3.4.*
+    pytest34: pytest-xdist<1.25.0
     pytest35: pytest==3.5.*
+    pytest35: pytest-xdist<1.25.0
     pytest36: pytest==3.6.*
+    pytest36: pytest-xdist>=1.25.0,<1.28.0
     pytest37: pytest==3.7.*
-    pytest-xdist
+    pytest37: pytest-xdist>=1.25.0,<1.28.0
     pdbpp
     rpdb
 commands =
@@ -38,7 +43,7 @@ whitelist_externals =
     sh
 deps =
     pytest==3.7.*
-    pytest-xdist
+    pytest-xdist>=1.25.0,<1.28.0
     coverage
     coveralls
 commands=


### PR DESCRIPTION
Make a subdirectory inside main logdir with symlinks to failed tests.