### PR TITLE
Add pytest_logger_logsdir hook

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -181,6 +181,20 @@ See: :py:meth:`LoggerConfig.split_by_outcome`
 
 .. _`link to logs dir`:
 
+Set the log directory
+---------------------------------------
+
+Implement the logsdir hook to place logs in a different directory.
+
+::
+
+    # content of conftest.py
+    import os
+    def pytest_logger_logsdir(config):
+        return os.path.join(os.path.dirname(__file__), 'logs')
+
+- see :py:meth:`LoggerHookspec.pytest_logger_logsdir`
+
 Link to logs directory
 ---------------------------------------
 

--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -73,6 +73,8 @@ class LoggerPlugin(object):
         logger_logsdir = self._config.getoption('logger_logsdir')
         if not logger_logsdir:
             logger_logsdir = self._config.getini('logger_logsdir')
+        if not logger_logsdir:
+            logger_logsdir = self._config.hook.pytest_logger_logsdir(config=self._config)
         if logger_logsdir:
             ldir = _make_logsdir_dir(logger_logsdir)
         else:
@@ -267,6 +269,21 @@ class LoggerHookspec(object):
         :arg config: pytest config object, holds e.g. options
 
         :return string: Absolute path of requested link to logs directory.
+        """
+
+    @pytest.hookspec(firstresult=True)
+    def pytest_logger_logsdir(self, config):
+        """ called after cmdline options parsing.
+        If implemented, place logs into the location returned. This is similar
+        to using --logger-logsdir or the logger_logsdir ini option, but will
+        only be used if those are not.
+
+        Additionally, if multiple implementations of this hook are found, only
+        the first non-None value will be used.
+
+        :arg config: pytest config object, holds e.g. options
+
+        :return string: Absolute path of logs directory.
         """
 
 

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -330,6 +330,25 @@ def test_logdir_link(testdir):
     assert ['test_case'] == ls(testdir.tmpdir, 'my_link_dir/test_case.py')
 
 
+def test_logsdir(testdir):
+    makefile(testdir, ['conftest.py'], """
+        import os
+        def pytest_logger_fileloggers(item):
+            return ['']
+        def pytest_logger_logsdir(config):
+            return os.path.join(os.path.dirname(__file__), 'my_logs_dir')
+    """)
+    makefile(testdir, ['test_case.py'], """
+        def test_case():
+            pass
+    """)
+
+    result = testdir.runpytest('-s')
+    assert result.ret == 0
+    assert 'my_logs_dir' in ls(testdir.tmpdir)
+    assert ['test_case'] == ls(testdir.tmpdir, 'my_logs_dir/test_case.py')
+
+
 def test_format(testdir):
     makefile(testdir, ['conftest.py'], """
         import os


### PR DESCRIPTION
It's not always practical to use --logger-logsdir or the logger_logsdir
ini option. Allow setting the logsdir value via a hook.

Signed-off-by: Zack Cerza <zack@redhat.com>