### PR TITLE
Modernize pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,21 @@ matrix:
     - python: '2.7'
       env: TOXENV='py27-pytest{35,36,37,4}'
     - python: '3.5'
-      env: TOXENV='py35-pytest{35,36,37,4}'
+      env: TOXENV='py35-pytest{3,4,5,6}'
     - python: '3.6'
-      env: TOXENV='py36-pytest{35,36,37,4}'
+      env: TOXENV='py36-pytest{3,4,5,6}'
     - python: '3.7'
       dist: xenial
       sudo: true
-      env: TOXENV='py37-pytest{35,36,37,4}'
-    - python: 'pypy-5.4'
+      env: TOXENV='py37-pytest{3,4,5,6}'
+    - python: '3.8'
+      dist: xenial
+      sudo: true
+      env: TOXENV='py38-pytest{3,4,5,6}'
+    - python: 'pypy'
       env: TOXENV='pypy-pytest{35,36,37,4}'
+    - python: 'pypy3'
+      env: TOXENV='pypy3-pytest{3,4,5,6}'
 before_install:
   - python --version
   - uname -a

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,10 @@ environment:
   matrix:
     - TOXENV: check
     - TOXENV: 'py27-pytest{35,36,37,4}'
-    - TOXENV: 'py35-pytest{35,36,37,4}'
-    - TOXENV: 'py36-pytest{35,36,37,4}'
-    - TOXENV: 'py37-pytest{35,36,37,4}'
+    - TOXENV: 'py35-pytest{3,4,5,6}'
+    - TOXENV: 'py36-pytest{3,4,5,6}'
+    - TOXENV: 'py37-pytest{3,4,5,6}'
+    - TOXENV: 'py38-pytest{3,4,5,6}'
     - TOXENV: 'pypy-pytest{35,36,37,4}'
 init:
   - ps: echo $env:TOXENV

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     check,
-    py{27,35,36,37,py}-pytest{35,36,37,4},
+    py{27,py}-pytest{35,36,37,4},
+    py{35,36,37,38,py3}-pytest{3,4,5,6},
     docs
 
 [testenv]
@@ -9,12 +10,20 @@ usedevelop = True
 deps =
     pytest35: pytest==3.5.*
     pytest35: pytest-xdist<1.25
+    pytest35: pytest-forked==1.0.*
     pytest36: pytest==3.6.*
     pytest36: pytest-xdist<1.25
+    pytest36: pytest-forked==1.0.*
     pytest37: pytest==3.7.*
     pytest37: pytest-xdist>=1.25,<1.28
+    pytest3: pytest==3.*
+    pytest3: pytest-xdist<1.28
     pytest4: pytest==4.*
-    pytest4: pytest-xdist
+    pytest4: pytest-xdist<2
+    pytest5: pytest==5.*
+    pytest5: pytest-xdist<2
+    pytest6: pytest==6.*
+    pytest6: pytest-xdist
     pdbpp
     rpdb
 commands =


### PR DESCRIPTION
1. pytest{3.5,3.6} have to use an old pytest-forked
1. pytest{4,5} have to use an old pytest-xdist
1. We now test against python3.8 and pypy3 as well as pytest{5,6}