### PR TITLE
fixed pytest warning

### DIFF
--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -101,7 +101,7 @@ class LoggerPlugin(object):
         if logger:
             logger.on_teardown()
 
-    @pytest.mark.hookwrapper
+    @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_makereport(self, item, call):
         outcome = yield
         tr = outcome.get_result()


### PR DESCRIPTION
PytestDeprecationWarning: The hookimpl LoggerPlugin.pytest_runtest_makereport uses old-style configuration options (marks or attributes).
Please use the pytest.hookimpl(hookwrapper=True) decorator instead
 to configure the hooks.
 See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers