### PR TITLE
Handle slashes in node_name

### DIFF
--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -318,11 +318,13 @@ def logdir(request):
     return _make_logdir(request._pyfuncitem)
 
 
-def _sanitize_nodeid(filename):
-    filename = filename.replace('::()::', '/')
-    filename = filename.replace('::', '/')
-    filename = re.sub(r'\[(.+)\]', r'-\1', filename)
-    return filename
+def _sanitize_nodeid(node_id):
+    tokens = node_id.split('::')
+    tokens[-1] = tokens[-1].replace('/', '-')
+    tokens[-1] = re.sub(r'-+', '-', tokens[-1])
+    node_id = '/'.join([x for x in tokens if x != '()'])
+    node_id = re.sub(r'\[(.+)\]', r'-\1', node_id)
+    return node_id
 
 
 def _sanitize_level(level, raises=True):

--- a/tests/test_pytest_logger.py
+++ b/tests/test_pytest_logger.py
@@ -338,15 +338,30 @@ def test_logsdir(testdir):
         def pytest_logger_logsdir(config):
             return os.path.join(os.path.dirname(__file__), 'my_logs_dir')
     """)
-    makefile(testdir, ['test_case.py'], """
-        def test_case():
+    makefile(testdir, ['test_cases.py'], """
+        import pytest
+
+        def test_simple():
+            pass
+
+        @pytest.mark.parametrize('param1, param2', [
+            ('x', 'a_b_c'),
+            ('y', 'd/e/f'),
+            ('z', '/g/h/i'),
+            ('v', '/j-1/k-1/l-1'),
+        ])
+        def test_param(param1, param2):
             pass
     """)
 
     result = testdir.runpytest('-s')
     assert result.ret == 0
     assert 'my_logs_dir' in ls(testdir.tmpdir)
-    assert ['test_case'] == ls(testdir.tmpdir, 'my_logs_dir/test_case.py')
+    assert 'test_simple' in ls(testdir.tmpdir, 'my_logs_dir/test_cases.py')
+    assert 'test_param-x-a_b_c' in ls(testdir.tmpdir, 'my_logs_dir/test_cases.py')
+    assert 'test_param-y-d-e-f' in ls(testdir.tmpdir, 'my_logs_dir/test_cases.py')
+    assert 'test_param-z-g-h-i' in ls(testdir.tmpdir, 'my_logs_dir/test_cases.py')
+    assert 'test_param-v-j-1-k-1-l-1' in ls(testdir.tmpdir, 'my_logs_dir/test_cases.py')
 
 
 def test_format(testdir):

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -12,6 +12,12 @@ def test_sanitize_nodeid():
         'parametrictests/test_z.py/test_param-2-abc'
     assert plugin._sanitize_nodeid('parametrictests/test_z.py::test_param[4.127-de]') == \
         'parametrictests/test_z.py/test_param-4.127-de'
+    assert plugin._sanitize_nodeid('parametrictests/test_z.py::test_param[x-a/b]') == \
+        'parametrictests/test_z.py/test_param-x-a-b'
+    assert plugin._sanitize_nodeid('parametrictests/test_z.py::test_param[y-/c/d]') == \
+        'parametrictests/test_z.py/test_param-y-c-d'
+    assert plugin._sanitize_nodeid('parametrictests/test_z.py::test_param[z-/e-1/f-1]') == \
+        'parametrictests/test_z.py/test_param-z-e-1-f-1'
 
 
 def test_sanitize_level():


### PR DESCRIPTION
There can be cases when strings containing slashes get into test name - eg. by being a parameter value.

Those need to be sanitized to avoid breaking the resulting path