### PR TITLE
Fix DeprecationWarning with newer Python versions

### DIFF
--- a/pytest_logger/plugin.py
+++ b/pytest_logger/plugin.py
@@ -307,7 +307,7 @@ class DefaultFormatter(logging.Formatter):
 
     def formatTime(self, record, datefmt=None):
         ct = record.created - self._start
-        dt = datetime.datetime.utcfromtimestamp(ct)
+        dt = datetime.datetime.fromtimestamp(ct, tz=datetime.timezone.utc)
         return dt.strftime("%M:%S.%f")[:-3]  # omit useconds, leave mseconds
 
     def format(self, record):


### PR DESCRIPTION
Using pytest-logger 1.1.0 with Python 3.12 results in the following DeprecationWarning:

  /Users/xxx/.venv/lib/python3.12/site-packages/pytest_logger/plugin.py:310: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    dt = datetime.datetime.utcfromtimestamp(ct)

This commit replaces `utcfromtimestamp` with `fromtimestamp(..., tz=datetime.timezone.utc)` 